### PR TITLE
FIRECERT-1567: GetMethodResponseHandler in IntentReader.js

### DIFF
--- a/src/IntentReader.js
+++ b/src/IntentReader.js
@@ -43,6 +43,7 @@ import SetApiResponseHandler from './pubsub/handlers/setApiResponseHandler';
 import LifecycleRecordHandler from './pubsub/handlers/lifecycleRecordHandler';
 import RegisterProviderHandler from './pubsub/handlers/RegisterProviderHandler';
 import GetEventResponse from './pubsub/handlers/GetEventResponse';
+import GetMethodResponseHandler from './pubsub/handlers/GetMethodResponseHandler';
 
 const logger = require('./utils/Logger')('IntentReader.js');
 
@@ -59,6 +60,7 @@ const handlers = {
   startLifecycleRecording: new LifecycleRecordHandler('startLifecycleRecording'),
   stopLifecycleRecording: new LifecycleRecordHandler('stopLifecycleRecording'),
   getEventResponse: new GetEventResponse('getEventResponse'),
+  getMethodResponse: new GetMethodResponseHandler('getMethodResponse'),
   [CONSTANTS.CALL_METHOD]: new CallMethodHandler(CONSTANTS.CALL_METHOD),
   [CONSTANTS.HEALTH_CHECK]: new HealthCheckHandler(CONSTANTS.HEALTH_CHECK),
 };

--- a/test/unit/IntentReader.test.js
+++ b/test/unit/IntentReader.test.js
@@ -45,6 +45,38 @@ process.env = {
   },
 };
 
+const mockFireboltExampleInvoker = {
+  invoke: () => {},
+};
+jest.mock('../../src/FireboltExampleInvoker', () => {
+  return {
+    get: () => {
+      return mockFireboltExampleInvoker;
+    },
+  };
+});
+
+jest.mock('@firebolt-js/sdk/dist/lib/Transport/index.mjs', () => {
+  return {
+    send: () => {
+      return {};
+    },
+  };
+});
+
+const mockFireboltTransportInvoker = {
+  invoke: jest.fn().mockImplementation(() => {
+    return Promise.resolve('success');
+  }),
+};
+jest.mock('../../src/FireboltTransportInvoker', () => {
+  return {
+    get: () => {
+      return mockFireboltTransportInvoker;
+    },
+  };
+});
+
 jest.mock('../../src/Toast', () => {
   const eventEmitter = {
     emit: jest.fn(),


### PR DESCRIPTION
# Description
Fix for RPC Only test cases failure in I register glue code

## JIRA Ticket
Include a link to the JIRA Ticket linked to this PR.
[FIRECERT-1567](https://ccp.sys.comcast.net/browse/FIRECERT-1567)

## Additional Info (Test steps / Steps to reproduce etc.)
Details on how to test the feature