### PR TITLE
SYSTEST-9703 - Remove success comment in github actions

### DIFF
--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -64,12 +64,12 @@ jobs:
         run: exit 1
 
       - name: Comment on PR
-        if: steps.comment.outputs.PR_COMMENT != 'Linting and unit tests succeeded.'
+        if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_COMMENT: ${{ steps.comment.outputs.PR_COMMENT }}
         run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+          if [[ "${{ github.event_name }}" == 'pull_request' && "$PR_COMMENT" != 'Linting and unit tests succeeded.' ]]; then
             JSON_PAYLOAD=$(jq -n --arg body "$PR_COMMENT" '{"body": $body}')
 
             echo "Generated JSON payload:"

--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -64,18 +64,20 @@ jobs:
         run: exit 1
 
       - name: Comment on PR
-        if: steps.comment.outputs.PR_COMMENT != 'Linting and unit tests succeeded.' && ${{ github.event_name }} == 'pull_request'
+        if: steps.comment.outputs.PR_COMMENT != 'Linting and unit tests succeeded.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_COMMENT: ${{ steps.comment.outputs.PR_COMMENT }}
         run: |
-          JSON_PAYLOAD=$(jq -n --arg body "$PR_COMMENT" '{"body": $body}')
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            JSON_PAYLOAD=$(jq -n --arg body "$PR_COMMENT" '{"body": $body}')
 
-          echo "Generated JSON payload:"
-          echo "$JSON_PAYLOAD"
+            echo "Generated JSON payload:"
+            echo "$JSON_PAYLOAD"
 
-          curl -X POST \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$JSON_PAYLOAD" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+            curl -X POST \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$JSON_PAYLOAD" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+          fi

--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -64,20 +64,18 @@ jobs:
         run: exit 1
 
       - name: Comment on PR
-        if: always()
+        if: steps.comment.outputs.PR_COMMENT != 'Linting and unit tests succeeded.' && ${{ github.event_name }} == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_COMMENT: ${{ steps.comment.outputs.PR_COMMENT }}
         run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            JSON_PAYLOAD=$(jq -n --arg body "$PR_COMMENT" '{"body": $body}')
+          JSON_PAYLOAD=$(jq -n --arg body "$PR_COMMENT" '{"body": $body}')
 
-            echo "Generated JSON payload:"
-            echo "$JSON_PAYLOAD"
+          echo "Generated JSON payload:"
+          echo "$JSON_PAYLOAD"
 
-            curl -X POST \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "$JSON_PAYLOAD" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
-          fi
+          curl -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$JSON_PAYLOAD" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"

--- a/src/App.js
+++ b/src/App.js
@@ -119,7 +119,7 @@ export default class App extends Base {
     }
     // Get values from Parameter.initialization - Start
     try {
-      await this.getParameterInitializationValues();
+      await this.getParameterInitializationValues()
     } catch (e) {
       logger.error(JSON.stringify(e), 'init');
     }

--- a/src/App.js
+++ b/src/App.js
@@ -119,7 +119,7 @@ export default class App extends Base {
     }
     // Get values from Parameter.initialization - Start
     try {
-      await this.getParameterInitializationValues()
+      await this.getParameterInitializationValues();
     } catch (e) {
       logger.error(JSON.stringify(e), 'init');
     }


### PR DESCRIPTION
# Description
Linting checks have been added to most of our tooling and we comment when there are failures. But we also comment when we pass. This makes it difficult to see the commits in PRs because there are often times many "Lint checking succeeded" comments in-between each commit.

By removing them we can clean up these PRs. It can be inferred that no comment means success.

## JIRA Ticket
Include a link to the JIRA Ticket linked to this PR.
[SYSTEST-9703](https://ccp.sys.comcast.net/browse/SYSTEST-9703)
