### PR TITLE
Add an explicit dependency for Winston-Transport 4.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "perf_hooks": "^0.0.1",
     "rxjs": "7.2.0",
     "uuid": "^9.0.0",
-    "winston": "^3.15.0",
+    "winston": "3.15.0",
+    "winston-transport": "4.7.1",
     "xml2js": "^0.5.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "perf_hooks": "^0.0.1",
     "rxjs": "7.2.0",
     "uuid": "^9.0.0",
-    "winston": "3.13.1",
+    "winston": "^3.15.0",
     "xml2js": "^0.5.0"
   },
   "scripts": {


### PR DESCRIPTION
# Description
Winston package internally consumes Winston-Transport. The latest release (4.8.0) of Winston-Transport introduces an incompatibility that may impact some platforms due to one of its dependencies increasing a major version. Winston itself does not have a hard dependency on the latest winston transport so adding a working version of winston-transport will still satisfy the requirements and prevent the incompatibility.

Set both Winston and Winston-transport to static versions which are working.